### PR TITLE
feat: add email notification preferences to user settings

### DIFF
--- a/packages/twenty-front/src/modules/settings/notifications/components/SettingsNotificationPreferencesSection.tsx
+++ b/packages/twenty-front/src/modules/settings/notifications/components/SettingsNotificationPreferencesSection.tsx
@@ -1,0 +1,50 @@
+import { useNotificationPreferences } from '@/settings/notifications/hooks/useNotificationPreferences';
+import { SettingsNotificationPreferencesSectionSkeletonLoader } from '@/settings/notifications/components/SettingsNotificationPreferencesSectionSkeletonLoader';
+import { useLingui } from '@lingui/react/macro';
+import { H2Title } from 'twenty-ui/display';
+import { Section } from 'twenty-ui/layout';
+import { SettingsAccountsToggleSettingCard } from '@/settings/accounts/components/SettingsAccountsToggleSettingCard';
+
+export const SettingsNotificationPreferencesSection = () => {
+  const { t } = useLingui();
+  const { preferences, loading, updateNotificationPreferences } =
+    useNotificationPreferences();
+
+  if (loading) {
+    return <SettingsNotificationPreferencesSectionSkeletonLoader />;
+  }
+
+  return (
+    <Section>
+      <H2Title
+        title={t`Email Notifications`}
+        description={t`Choose which email notifications you want to receive`}
+      />
+      <SettingsAccountsToggleSettingCard
+        parameters={[
+          {
+            value: preferences.newRecordAssignments,
+            title: t`New record assignments`,
+            description: t`Receive an email when a record is assigned to you`,
+            onToggle: (value) =>
+              updateNotificationPreferences({ newRecordAssignments: value }),
+          },
+          {
+            value: preferences.taskDueDateReminders,
+            title: t`Task due date reminders`,
+            description: t`Receive an email reminder before a task is due`,
+            onToggle: (value) =>
+              updateNotificationPreferences({ taskDueDateReminders: value }),
+          },
+          {
+            value: preferences.weeklyActivityDigest,
+            title: t`Weekly activity digest`,
+            description: t`Receive a weekly summary of activity in your workspace`,
+            onToggle: (value) =>
+              updateNotificationPreferences({ weeklyActivityDigest: value }),
+          },
+        ]}
+      />
+    </Section>
+  );
+};

--- a/packages/twenty-front/src/modules/settings/notifications/components/SettingsNotificationPreferencesSectionSkeletonLoader.tsx
+++ b/packages/twenty-front/src/modules/settings/notifications/components/SettingsNotificationPreferencesSectionSkeletonLoader.tsx
@@ -1,0 +1,55 @@
+import { SKELETON_LOADER_HEIGHT_SIZES } from '@/activities/components/SkeletonLoader';
+import { styled } from '@linaria/react';
+import { useContext } from 'react';
+import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
+import { Section } from 'twenty-ui/layout';
+import { ThemeContext, themeCssVariables } from 'twenty-ui/theme-constants';
+
+const StyledSkeletonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${themeCssVariables.spacing[3]};
+  padding: ${themeCssVariables.spacing[2]} 0;
+`;
+
+const StyledSkeletonRow = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: ${themeCssVariables.spacing[2]} 0;
+`;
+
+const SKELETON_ROWS = [{ width: 200 }, { width: 180 }, { width: 220 }];
+
+export const SettingsNotificationPreferencesSectionSkeletonLoader = () => {
+  const { theme } = useContext(ThemeContext);
+  return (
+    <Section>
+      <SkeletonTheme
+        baseColor={theme.background.tertiary}
+        highlightColor={theme.background.transparent.lighter}
+        borderRadius={4}
+      >
+        <Skeleton
+          height={SKELETON_LOADER_HEIGHT_SIZES.standard.m}
+          width={160}
+          style={{ marginBottom: themeCssVariables.spacing[2] }}
+        />
+        <StyledSkeletonContainer>
+          {SKELETON_ROWS.map((row, index) => (
+            <StyledSkeletonRow key={index}>
+              <Skeleton
+                height={SKELETON_LOADER_HEIGHT_SIZES.standard.s}
+                width={row.width}
+              />
+              <Skeleton
+                height={SKELETON_LOADER_HEIGHT_SIZES.standard.m}
+                width={36}
+              />
+            </StyledSkeletonRow>
+          ))}
+        </StyledSkeletonContainer>
+      </SkeletonTheme>
+    </Section>
+  );
+};

--- a/packages/twenty-front/src/modules/settings/notifications/components/index.ts
+++ b/packages/twenty-front/src/modules/settings/notifications/components/index.ts
@@ -1,0 +1,2 @@
+export { SettingsNotificationPreferencesSection } from './SettingsNotificationPreferencesSection';
+export { SettingsNotificationPreferencesSectionSkeletonLoader } from './SettingsNotificationPreferencesSectionSkeletonLoader';

--- a/packages/twenty-front/src/modules/settings/notifications/graphql/index.ts
+++ b/packages/twenty-front/src/modules/settings/notifications/graphql/index.ts
@@ -1,0 +1,2 @@
+export { GET_NOTIFICATION_PREFERENCES } from './queries/getNotificationPreferences';
+export { UPDATE_NOTIFICATION_PREFERENCES } from './mutations/updateNotificationPreferences';

--- a/packages/twenty-front/src/modules/settings/notifications/graphql/mutations/updateNotificationPreferences.ts
+++ b/packages/twenty-front/src/modules/settings/notifications/graphql/mutations/updateNotificationPreferences.ts
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+export const UPDATE_NOTIFICATION_PREFERENCES = gql`
+  mutation UpdateNotificationPreferences(
+    $input: UpdateNotificationPreferencesInput!
+  ) {
+    updateNotificationPreferences(input: $input) {
+      newRecordAssignments
+      taskDueDateReminders
+      weeklyActivityDigest
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/settings/notifications/graphql/queries/getNotificationPreferences.ts
+++ b/packages/twenty-front/src/modules/settings/notifications/graphql/queries/getNotificationPreferences.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client';
+
+export const GET_NOTIFICATION_PREFERENCES = gql`
+  query GetNotificationPreferences {
+    getNotificationPreferences {
+      newRecordAssignments
+      taskDueDateReminders
+      weeklyActivityDigest
+    }
+  }
+`;

--- a/packages/twenty-front/src/modules/settings/notifications/hooks/index.ts
+++ b/packages/twenty-front/src/modules/settings/notifications/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useNotificationPreferences } from './useNotificationPreferences';

--- a/packages/twenty-front/src/modules/settings/notifications/hooks/useNotificationPreferences.ts
+++ b/packages/twenty-front/src/modules/settings/notifications/hooks/useNotificationPreferences.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery } from '@apollo/client';
+
+import { GET_NOTIFICATION_PREFERENCES } from '@/settings/notifications/graphql/queries/getNotificationPreferences';
+import { UPDATE_NOTIFICATION_PREFERENCES } from '@/settings/notifications/graphql/mutations/updateNotificationPreferences';
+
+type NotificationPreferences = {
+  newRecordAssignments: boolean;
+  taskDueDateReminders: boolean;
+  weeklyActivityDigest: boolean;
+};
+
+type UpdateNotificationPreferencesInput = Partial<NotificationPreferences>;
+
+export const useNotificationPreferences = () => {
+  const { data, loading } = useQuery<{
+    getNotificationPreferences: NotificationPreferences;
+  }>(GET_NOTIFICATION_PREFERENCES);
+
+  const [updatePreferences, { loading: updating }] = useMutation<
+    { updateNotificationPreferences: NotificationPreferences },
+    { input: UpdateNotificationPreferencesInput }
+  >(UPDATE_NOTIFICATION_PREFERENCES);
+
+  const preferences: NotificationPreferences =
+    data?.getNotificationPreferences ?? {
+      newRecordAssignments: true,
+      taskDueDateReminders: true,
+      weeklyActivityDigest: true,
+    };
+
+  const updateNotificationPreferences = async (
+    input: UpdateNotificationPreferencesInput,
+  ) => {
+    await updatePreferences({
+      variables: { input },
+      optimisticResponse: {
+        updateNotificationPreferences: {
+          ...preferences,
+          ...input,
+        },
+      },
+      update: (cache, { data: mutationData }) => {
+        if (!mutationData) return;
+        cache.writeQuery({
+          query: GET_NOTIFICATION_PREFERENCES,
+          data: {
+            getNotificationPreferences:
+              mutationData.updateNotificationPreferences,
+          },
+        });
+      },
+    });
+  };
+
+  return {
+    preferences,
+    loading,
+    updating,
+    updateNotificationPreferences,
+  };
+};

--- a/packages/twenty-front/src/modules/settings/notifications/hooks/useNotificationPreferences.ts
+++ b/packages/twenty-front/src/modules/settings/notifications/hooks/useNotificationPreferences.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery } from '@apollo/client';
 
 import { GET_NOTIFICATION_PREFERENCES } from '@/settings/notifications/graphql/queries/getNotificationPreferences';
 import { UPDATE_NOTIFICATION_PREFERENCES } from '@/settings/notifications/graphql/mutations/updateNotificationPreferences';
+import { useSnackBar } from '@/ui/feedback/snack-bar-manager/hooks/useSnackBar';
 
 type NotificationPreferences = {
   newRecordAssignments: boolean;
@@ -12,6 +13,8 @@ type NotificationPreferences = {
 type UpdateNotificationPreferencesInput = Partial<NotificationPreferences>;
 
 export const useNotificationPreferences = () => {
+  const { enqueueErrorSnackBar } = useSnackBar();
+
   const { data, loading } = useQuery<{
     getNotificationPreferences: NotificationPreferences;
   }>(GET_NOTIFICATION_PREFERENCES);
@@ -31,25 +34,29 @@ export const useNotificationPreferences = () => {
   const updateNotificationPreferences = async (
     input: UpdateNotificationPreferencesInput,
   ) => {
-    await updatePreferences({
-      variables: { input },
-      optimisticResponse: {
-        updateNotificationPreferences: {
-          ...preferences,
-          ...input,
-        },
-      },
-      update: (cache, { data: mutationData }) => {
-        if (!mutationData) return;
-        cache.writeQuery({
-          query: GET_NOTIFICATION_PREFERENCES,
-          data: {
-            getNotificationPreferences:
-              mutationData.updateNotificationPreferences,
+    try {
+      await updatePreferences({
+        variables: { input },
+        optimisticResponse: {
+          updateNotificationPreferences: {
+            ...preferences,
+            ...input,
           },
-        });
-      },
-    });
+        },
+        update: (cache, { data: mutationData }) => {
+          if (!mutationData) return;
+          cache.writeQuery({
+            query: GET_NOTIFICATION_PREFERENCES,
+            data: {
+              getNotificationPreferences:
+                mutationData.updateNotificationPreferences,
+            },
+          });
+        },
+      });
+    } catch (error) {
+      enqueueErrorSnackBar({ apolloError: error as Error });
+    }
   };
 
   return {

--- a/packages/twenty-front/src/pages/settings/notifications/SettingsNotifications.tsx
+++ b/packages/twenty-front/src/pages/settings/notifications/SettingsNotifications.tsx
@@ -1,0 +1,27 @@
+import { SettingsPageContainer } from '@/settings/components/SettingsPageContainer';
+import { SettingsNotificationPreferencesSection } from '@/settings/notifications/components/SettingsNotificationPreferencesSection';
+import { SubMenuTopBarContainer } from '@/ui/layout/page/components/SubMenuTopBarContainer';
+import { Trans, useLingui } from '@lingui/react/macro';
+import { SettingsPath } from 'twenty-shared/types';
+import { getSettingsPath } from 'twenty-shared/utils';
+
+export const SettingsNotifications = () => {
+  const { t } = useLingui();
+
+  return (
+    <SubMenuTopBarContainer
+      title={t`Notifications`}
+      links={[
+        {
+          children: <Trans>User</Trans>,
+          href: getSettingsPath(SettingsPath.ProfilePage),
+        },
+        { children: <Trans>Notifications</Trans> },
+      ]}
+    >
+      <SettingsPageContainer>
+        <SettingsNotificationPreferencesSection />
+      </SettingsPageContainer>
+    </SubMenuTopBarContainer>
+  );
+};

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1773330000000-add-notification-preferences-to-user-workspace.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1773330000000-add-notification-preferences-to-user-workspace.ts
@@ -7,7 +7,7 @@ export class AddNotificationPreferencesToUserWorkspace1773330000000
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "core"."userWorkspace" ADD "notificationPreferences" jsonb`,
+      `ALTER TABLE "core"."userWorkspace" ADD "notificationPreferences" jsonb NOT NULL DEFAULT '{"newRecordAssignments":true,"taskDueDateReminders":true,"weeklyActivityDigest":true}'::jsonb`,
     );
   }
 

--- a/packages/twenty-server/src/database/typeorm/core/migrations/common/1773330000000-add-notification-preferences-to-user-workspace.ts
+++ b/packages/twenty-server/src/database/typeorm/core/migrations/common/1773330000000-add-notification-preferences-to-user-workspace.ts
@@ -1,0 +1,19 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddNotificationPreferencesToUserWorkspace1773330000000
+  implements MigrationInterface
+{
+  name = 'AddNotificationPreferencesToUserWorkspace1773330000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" ADD "notificationPreferences" jsonb`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "core"."userWorkspace" DROP COLUMN "notificationPreferences"`,
+    );
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/user/dtos/notification-preferences.dto.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/dtos/notification-preferences.dto.ts
@@ -1,0 +1,25 @@
+import { Field, InputType, ObjectType } from '@nestjs/graphql';
+
+@ObjectType('NotificationPreferences')
+export class NotificationPreferencesDTO {
+  @Field({ nullable: false, defaultValue: true })
+  newRecordAssignments: boolean;
+
+  @Field({ nullable: false, defaultValue: true })
+  taskDueDateReminders: boolean;
+
+  @Field({ nullable: false, defaultValue: true })
+  weeklyActivityDigest: boolean;
+}
+
+@InputType()
+export class UpdateNotificationPreferencesInput {
+  @Field({ nullable: true })
+  newRecordAssignments?: boolean;
+
+  @Field({ nullable: true })
+  taskDueDateReminders?: boolean;
+
+  @Field({ nullable: true })
+  weeklyActivityDigest?: boolean;
+}

--- a/packages/twenty-server/src/engine/core-modules/user/notification-preferences.resolver.ts
+++ b/packages/twenty-server/src/engine/core-modules/user/notification-preferences.resolver.ts
@@ -1,0 +1,48 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Mutation, Query } from '@nestjs/graphql';
+
+import { MetadataResolver } from 'src/engine/api/graphql/graphql-config/decorators/metadata-resolver.decorator';
+import { type AuthContextUser } from 'src/engine/core-modules/auth/types/auth-context.type';
+import { UserWorkspaceService } from 'src/engine/core-modules/user-workspace/user-workspace.service';
+import {
+  NotificationPreferencesDTO,
+  UpdateNotificationPreferencesInput,
+} from 'src/engine/core-modules/user/dtos/notification-preferences.dto';
+import { WorkspaceEntity } from 'src/engine/core-modules/workspace/workspace.entity';
+import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
+import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
+import { UserAuthGuard } from 'src/engine/guards/user-auth.guard';
+import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
+
+@MetadataResolver(() => NotificationPreferencesDTO)
+export class NotificationPreferencesResolver {
+  constructor(
+    private readonly userWorkspaceService: UserWorkspaceService,
+  ) {}
+
+  @Query(() => NotificationPreferencesDTO)
+  @UseGuards(UserAuthGuard, WorkspaceAuthGuard)
+  async getNotificationPreferences(
+    @AuthUser() { id: userId }: AuthContextUser,
+    @AuthWorkspace() workspace: WorkspaceEntity,
+  ): Promise<NotificationPreferencesDTO> {
+    return this.userWorkspaceService.getNotificationPreferences(
+      userId,
+      workspace.id,
+    );
+  }
+
+  @Mutation(() => NotificationPreferencesDTO)
+  @UseGuards(UserAuthGuard, WorkspaceAuthGuard)
+  async updateNotificationPreferences(
+    @Args('input') input: UpdateNotificationPreferencesInput,
+    @AuthUser() { id: userId }: AuthContextUser,
+    @AuthWorkspace() workspace: WorkspaceEntity,
+  ): Promise<NotificationPreferencesDTO> {
+    return this.userWorkspaceService.updateNotificationPreferences(
+      userId,
+      workspace.id,
+      input,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implements #3.

- Add `notificationPreferences` JSONB column to `userWorkspace` entity via TypeORM migration
- Add GraphQL query (`getNotificationPreferences`) and mutation (`updateNotificationPreferences`) via new `NotificationPreferencesResolver`
- Add business logic in `UserWorkspaceService` following the repository pattern
- Add frontend settings page under Settings → Notifications with toggles for three preference types

## Changes

- `packages/twenty-server/src/database/typeorm/core/migrations/common/1773330000000-add-notification-preferences-to-user-workspace.ts` — migration adding nullable JSONB column
- `packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.entity.ts` — new `notificationPreferences` field
- `packages/twenty-server/src/engine/core-modules/user-workspace/user-workspace.service.ts` — new service methods
- `packages/twenty-server/src/engine/core-modules/user/notification-preferences.resolver.ts` — new GraphQL resolver
- `packages/twenty-server/src/engine/core-modules/user/dtos/notification-preferences.dto.ts` — DTO types
- `packages/twenty-front/src/modules/settings/notifications/` — frontend components, hooks, GraphQL ops
- `packages/twenty-front/src/pages/settings/notifications/SettingsNotifications.tsx` — settings page

## Test Plan

- [ ] Run migration: `npx nx run twenty-server:database:migrate:prod`
- [ ] Navigate to Settings → Notifications and verify three toggles appear
- [ ] Toggle a preference and reload — verify it persists
- [ ] Check GraphQL playground: `getNotificationPreferences` query returns defaults for new users
- [ ] Run `npx nx typecheck twenty-server` and `npx nx typecheck twenty-front`